### PR TITLE
rubocop修正: 曖昧な正規表現リテラル、procスタイル、スペーシングの問題を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,8 +113,8 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
   config.middleware.insert_before(Rack::Runtime, Rack::Rewrite) do
-    r301 %r{.*}, 'https://wavecongra.com$&', if: Proc.new { |rack_env|
+    r301(/.*/, 'https://wavecongra.com$&', if: proc { |rack_env|
       rack_env['SERVER_NAME'] == 'wavecongra.onrender.com'
-    }
+    })
   end
 end


### PR DESCRIPTION
正規表現リテラルの周りに//を使用し、Proc.newをprocに置き換え、必要なスペーシングを追加しました。