### PR TITLE
Fix: 本番環境用のアセットパイプラインを設定

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # exit on error
 set -o errexit
+set -o pipefail
+
+export RAILS_ENV=production
 
 bundle install
-bundle exec rails assets:precompile
+bundle exec rails assets:precompile || {
+  echo "Asset precompilation failed"
+  exit 1
+}
 bundle exec rails assets:clean
-# DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:migrate:reset
 bundle exec rails db:migrate


### PR DESCRIPTION
 本番環境でのアセットパイプライン設定を修正
キャッシュ破棄のために config.assets.digest を有効化
アセットプリコンパイルに関する設定を更新
