### PR TITLE
Fix: 必要なアセットをプリコンパイルリストに追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
application.css、application.tailwind.css、およびcustom.cssをアセットプリコンパイルリストに追加。

この変更により、これらのスタイルシートがプリコンパイルされ、本番環境で利用可能になります。