### PR TITLE
Fix: プリコンパイルアセットの設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
本番環境で必要なアセットをプリコンパイルリストに追加し、パフォーマンスを向上させるためにconfig.assets.compileをfalseに設定。

application.css、application.tailwind.css、およびcustom.cssをプリコンパイルリストに追加。