### PR TITLE
Fix: アセットプリコンパイル設定の修正

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w[application.js application.tailwind.css custom.css]
+Rails.application.config.assets.precompile += %w(application.js application.css custom.css)


### PR DESCRIPTION
本番環境でのアセット提供を正しく行うための設定修正

stylesheet_link_tagをapplication.cssに統一